### PR TITLE
fix: data is not requested when navigating back using browser or mobile

### DIFF
--- a/components/galgame/Container.tsx
+++ b/components/galgame/Container.tsx
@@ -174,7 +174,7 @@ export const CardContainer = ({ initialGalgames, initialTotal }: Props) => {
           <KunPagination
             total={Math.ceil(total / 24)}
             page={page}
-            onPageChange={() => setPage(page)}
+            onPageChange={setPage}
             isLoading={loading}
           />
         </div>

--- a/components/galgame/Container.tsx
+++ b/components/galgame/Container.tsx
@@ -50,6 +50,29 @@ export const CardContainer = ({ initialGalgames, initialTotal }: Props) => {
     if (!isMounted) {
       return
     }
+
+    // url 更新 state，确保浏览器返回时 state 更新，并重新 fetch
+    setSelectedType(searchParams.get('type') || 'all')
+    setSelectedLanguage(searchParams.get('language') || 'all')
+    setSelectedPlatform(searchParams.get('platform') || 'all')
+    setSortField(
+      (searchParams.get('sortField') as SortField) || 'resource_update_time'
+    )
+    setSortOrder((searchParams.get('sortOrder') as SortOrder) || 'desc')
+    setSelectedYears(
+      JSON.parse(searchParams.get('selectedYears') as string) || ['all']
+    )
+    setSelectedMonths(
+      JSON.parse(searchParams.get('selectedMonths') as string) || ['all']
+    )
+    setPage(Number(searchParams.get('page')) || 1)
+  }, [searchParams.toString()])
+
+  useEffect(() => {
+    if (!isMounted) {
+      return
+    }
+
     const params = new URLSearchParams()
 
     params.set('type', selectedType)
@@ -74,8 +97,7 @@ export const CardContainer = ({ initialGalgames, initialTotal }: Props) => {
     selectedYears,
     selectedMonths,
     page,
-    isMounted,
-    router
+    isMounted
   ])
 
   const fetchPatches = async () => {
@@ -152,7 +174,7 @@ export const CardContainer = ({ initialGalgames, initialTotal }: Props) => {
           <KunPagination
             total={Math.ceil(total / 24)}
             page={page}
-            onPageChange={setPage}
+            onPageChange={() => setPage(page)}
             isLoading={loading}
           />
         </div>

--- a/components/kun/Pagination.tsx
+++ b/components/kun/Pagination.tsx
@@ -25,6 +25,10 @@ export const KunPagination = ({
   const [isEditing, setIsEditing] = useState(false)
   const [inputValue, setInputValue] = useState(String(page))
 
+  useEffect(() => {
+    onPageChange(Number(searchParams.get('page')) || 1)
+  }, [searchParams.toString()])
+
   const createQueryString = (name: string, value: string) => {
     const params = new URLSearchParams(searchParams.toString())
     params.set(name, value)

--- a/components/resource/Container.tsx
+++ b/components/resource/Container.tsx
@@ -18,6 +18,8 @@ interface Props {
   initialTotal: number
 }
 
+const PAGE_LIMIT = 50
+
 export const CardContainer = ({ initialResources, initialTotal }: Props) => {
   const [resources, setResources] = useState<PatchResource[]>(initialResources)
   const [total, setTotal] = useState(initialTotal)
@@ -29,6 +31,10 @@ export const CardContainer = ({ initialResources, initialTotal }: Props) => {
   const searchParams = useSearchParams()
   const [page, setPage] = useState(Number(searchParams.get('page')) || 1)
 
+  useEffect(() => {
+    setPage(Number(searchParams.get('page')) || 1)
+  }, [searchParams.toString()])
+
   const fetchData = async () => {
     setLoading(true)
 
@@ -39,7 +45,7 @@ export const CardContainer = ({ initialResources, initialTotal }: Props) => {
       sortField,
       sortOrder,
       page,
-      limit: 50
+      limit: PAGE_LIMIT
     })
 
     setResources(resources)
@@ -85,10 +91,10 @@ export const CardContainer = ({ initialResources, initialTotal }: Props) => {
         </KunMasonryGrid>
       )}
 
-      {total > 50 && (
+      {total > PAGE_LIMIT && (
         <div className="flex justify-center">
           <KunPagination
-            total={Math.ceil(total / 50)}
+            total={Math.ceil(total / PAGE_LIMIT)}
             page={page}
             onPageChange={setPage}
             isLoading={loading}

--- a/components/tag/Container.tsx
+++ b/components/tag/Container.tsx
@@ -15,6 +15,8 @@ interface Props {
   initialTotal: number
 }
 
+const PAGE_LIMIT = 100
+
 export const Container = ({ initialTags, initialTotal }: Props) => {
   const [tags, setTags] = useState<TagType[]>(initialTags)
   const [page, setPage] = useState(1)
@@ -29,7 +31,7 @@ export const Container = ({ initialTags, initialTotal }: Props) => {
       total: number
     }>('/tag/all', {
       page,
-      limit: 100
+      limit: PAGE_LIMIT
     })
     setTags(tags)
     setTotal(total)
@@ -83,10 +85,10 @@ export const Container = ({ initialTags, initialTotal }: Props) => {
         <TagList tags={tags} loading={loading} searching={searching} />
       )}
 
-      {total > 100 && !query && (
+      {total > PAGE_LIMIT && !query && (
         <div className="flex justify-center">
           <KunPagination
-            total={Math.ceil(total / 100)}
+            total={Math.ceil(total / PAGE_LIMIT)}
             page={page}
             onPageChange={setPage}
             isLoading={loading}


### PR DESCRIPTION
通过浏览器或手机导航返回时，无法重新请求页面的展示数据（该问题存在于有 url 搜索参数的页面）

复现步骤：

打开网站，存在 url 参数的页面（galgame、tag、resource）均可复现。