### PR TITLE
fix(ui): adapt 4:3 video aspect ratio in player

### DIFF
--- a/components/patch/introduction/IntroductionTab.tsx
+++ b/components/patch/introduction/IntroductionTab.tsx
@@ -104,12 +104,13 @@ const LazyKunPlyr = ({ src, autoPlay }: { src: string; autoPlay: boolean }) => {
     <div className="relative w-full aspect-video overflow-hidden rounded-xl bg-black">
       {!isReady && <VideoLoadingPlaceholder />}
       <div
-        className={`absolute inset-0 [&_.plyr]:h-full [&_.plyr]:w-full [&_.plyr__video-wrapper]:h-full [&_video]:h-full [&_video]:w-full ${
+        className={`absolute inset-0 [&_.plyr]:h-full [&_.plyr]:w-full [&_.plyr__video-wrapper]:h-full [&_video]:h-full [&_video]:w-full [&_video]:object-contain [&_video]:object-center ${
           isReady ? 'opacity-100' : 'pointer-events-none opacity-0'
         }`}
       >
         <KunPlyr
           src={src}
+          className="h-full w-full object-contain object-center"
           autoPlay={autoPlay}
           onReady={() => setIsReady(true)}
         />


### PR DESCRIPTION
 ## Summary
修复 4:3 等非 16:9 视频在播放器中溢出的问题，

下面是示意图，用于测试原始页面是 https://www.touchgal.ink/8cfd5064
### 修复前
<img width="2499" height="1288" alt="image" src="https://github.com/user-attachments/assets/3517fce3-de52-48de-b6ac-1880f5ddbac6" />
并且也看不见进度条，暂停的时候发现原本应该居中的播放按钮位置偏下了

### 修复后
本地复刻了一下页面数据，修复后的效果
<img width="2473" height="1305" alt="image" src="https://github.com/user-attachments/assets/b401cc3e-e75a-4271-b571-16ad8277e6f3" />

## Root Cause
视频元素默认使用 `object-fit: fill`，导致非 16:9 视频被拉伸或溢出容器。

## Changes
- 为 video 元素添加 `object-contain` 和 `object-center`，使其在保持宽高比的同时居中显示于容器内 
- 通过 Tailwind 任意选择器 `[&_video]` 和 KunPlyr 组件的 `className` prop 双重覆盖

## 验证
- 本地测试
- `pnpm typecheck`